### PR TITLE
Fix incompatible character encodings

### DIFF
--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -76,7 +76,8 @@ module ExceptionNotifier
               when Hash, Array
                 object.inspect
               else
-                object.to_s
+                object_str = object.to_s
+                object_str.frozen? ? object_str.dup : object_str
             end.force_encoding(self.headers[:charset] || 'UTF-8')
           end
 

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "active_support/core_ext/hash/reverse_merge"
 require 'action_mailer'
 require 'action_dispatch'
@@ -75,10 +77,7 @@ module ExceptionNotifier
                 object.inspect
               else
                 object.to_s
-            end.encode(
-                'UTF-8',
-                { :invalid => :replace, :undef => :replace, :replace => '?' }
-            )
+            end.force_encoding(self.headers[:charset] || 'UTF-8')
           end
 
           def html_mail?

--- a/lib/exception_notifier/email_notifier.rb
+++ b/lib/exception_notifier/email_notifier.rb
@@ -75,7 +75,10 @@ module ExceptionNotifier
                 object.inspect
               else
                 object.to_s
-            end
+            end.encode(
+                'UTF-8',
+                { :invalid => :replace, :undef => :replace, :replace => '?' }
+            )
           end
 
           def html_mail?

--- a/lib/exception_notifier/views/exception_notifier/_environment.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_environment.text.erb
@@ -1,5 +1,5 @@
 <% filtered_env = @request.filtered_env -%>
 <% max = filtered_env.keys.map(&:to_s).max { |a, b| a.length <=> b.length } -%>
 <% filtered_env.keys.map(&:to_s).sort.each do |key| -%>
-* <%= raw("%-*s: %s" % [max.length, key, inspect_object(filtered_env[key])]) %>
+* <%= raw("%-*s: %s" % [max.length + 1, key, inspect_object(filtered_env[key])]) %>
 <% end -%>

--- a/lib/exception_notifier/views/exception_notifier/_request.html.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.html.erb
@@ -13,7 +13,7 @@
   </li>
   <li>
     <strong>Parameters:</strong>
-    <span><%= @request.filtered_parameters.inspect %></span>
+    <span><%= inspect_object(@request.filtered_parameters) %></span>
   </li>
   <li>
     <strong>Timestamp:</strong>

--- a/lib/exception_notifier/views/exception_notifier/_request.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.text.erb
@@ -1,7 +1,7 @@
 * URL        : <%= raw @request.url %>
 * HTTP Method: <%= raw @request.request_method %>
 * IP address : <%= raw @request.remote_ip %>
-* Parameters : <%= raw @request.filtered_parameters.inspect %>
+* Parameters : <%= raw inspect_object(@request.filtered_parameters) %>
 * Timestamp  : <%= raw Time.current %>
 * Server : <%= raw Socket.gethostname %>
 <% if defined?(Rails) && Rails.respond_to?(:root) %>

--- a/lib/exception_notifier/views/exception_notifier/_request.text.erb
+++ b/lib/exception_notifier/views/exception_notifier/_request.text.erb
@@ -1,10 +1,10 @@
-* URL        : <%= raw @request.url %>
-* HTTP Method: <%= raw @request.request_method %>
-* IP address : <%= raw @request.remote_ip %>
-* Parameters : <%= raw inspect_object(@request.filtered_parameters) %>
-* Timestamp  : <%= raw Time.current %>
-* Server : <%= raw Socket.gethostname %>
+* URL         : <%= raw inspect_object(@request.url) %>
+* HTTP Method : <%= raw @request.request_method %>
+* IP address  : <%= raw @request.remote_ip %>
+* Parameters  : <%= raw inspect_object(@request.filtered_parameters) %>
+* Timestamp   : <%= raw Time.current %>
+* Server      : <%= raw Socket.gethostname %>
 <% if defined?(Rails) && Rails.respond_to?(:root) %>
-* Rails root : <%= raw Rails.root %>
+* Rails root  : <%= raw Rails.root %>
 <% end %>
-* Process: <%= raw $$ %>
+* Process     : <%= raw $$ %>

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    exception_notification (4.1.0.rc1)
+    exception_notification (4.1.0)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
 

--- a/test/dummy/test/functional/posts_controller_test.rb
+++ b/test/dummy/test/functional/posts_controller_test.rb
@@ -46,7 +46,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   test "mail should contain timestamp of exception in body" do
-    assert @mail.encoded.include? "Timestamp  : #{Time.current}"
+    assert @mail.encoded.include? "Timestamp   : #{Time.current}"
   end
 
   test "mail should contain the newly defined section" do

--- a/test/exception_notifier/email_notifier_request_test.rb
+++ b/test/exception_notifier/email_notifier_request_test.rb
@@ -12,7 +12,7 @@ class EmailNotifierRequestTest < ActiveSupport::TestCase
       @mail      = @email_notifier.create_email(
           @exception,
           :env => {
-              'REQUEST_METHOD' => 'GET',
+              'REQUEST_METHOD' => 'GET'.freeze,
               'HTTP_HOST'      => 'example.com',
               'QUERY_STRING'   => 'data=привет&utf8=✓'.b,
               'rack.input'     => true

--- a/test/exception_notifier/email_notifier_request_test.rb
+++ b/test/exception_notifier/email_notifier_request_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class EmailNotifierRequestTest < ActiveSupport::TestCase
+  setup do
+    Time.stubs(:current).returns('Sat, 20 Apr 2013 20:58:55 UTC +00:00')
+
+    @email_notifier = ExceptionNotifier.registered_exception_notifier(:email)
+    begin
+      1/0
+    rescue => e
+      @exception = e
+      @mail      = @email_notifier.create_email(
+          @exception,
+          :env => {
+              'REQUEST_METHOD' => 'GET',
+              'HTTP_HOST'      => 'example.com',
+              'QUERY_STRING'   => 'data=привет&utf8=✓'.b,
+              'rack.input'     => true
+          }
+      )
+    end
+  end
+
+  test "request mail should contain unicode in body" do
+    assert @mail.body.include? '✓'
+    assert @mail.body.include? 'привет'
+  end
+
+end


### PR DESCRIPTION
In some cases Rails may get a malformed request with binary string in `QUERY_STRING`. In this cases `ActionDispatch::Request#filtered_parameters` and Rack `env` hash can't be converted into string and rendered into ERB template correctly.

Trying to do so ends with "ActionView::Template::Error: incompatible character encodings: ASCII-8BIT and UTF-8" error in section generation routine.

This PR forces the encoding of strings to be equal with email character set (UTF-8 by default).

Tests are included.
